### PR TITLE
Fix Team page dark-mode and clean up some types (#552)

### DIFF
--- a/src/components/team/copy-to-clipboard.tsx
+++ b/src/components/team/copy-to-clipboard.tsx
@@ -1,0 +1,58 @@
+import * as React from 'react'
+import {FunctionComponent} from 'react'
+import useClipboard from 'react-use-clipboard'
+
+const IconLink: FunctionComponent<{className?: string}> = ({
+  className = '',
+}) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke="currentColor"
+    className={className}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1"
+    />
+  </svg>
+)
+
+const CopyToClipboard: FunctionComponent<{
+  stringToCopy: string
+  className?: string
+  label?: boolean
+}> = ({stringToCopy = '', className = '', label = false}) => {
+  const [isCopied, setCopied] = useClipboard(stringToCopy, {
+    successDuration: 1000,
+  })
+
+  return (
+    <div className={className}>
+      <button
+        type="button"
+        onClick={setCopied}
+        className={`md:h-full group flex text-sm items-center space-x-1 rounded px-3 py-2 bg-gray-50 dark:bg-gray-700 hover:bg-blue-100 dark:hover:bg-gray-800 hover:text-blue-600 dark:hover:text-white transition-colors ease-in-out duration-150`}
+      >
+        {isCopied ? (
+          'Copied'
+        ) : (
+          <>
+            <IconLink className="w-5" />
+            {label && (
+              <span>
+                Copy link
+                <span className="hidden lg:inline"> to clipboard</span>
+              </span>
+            )}
+          </>
+        )}
+      </button>
+    </div>
+  )
+}
+
+export default CopyToClipboard

--- a/src/components/team/team-name.tsx
+++ b/src/components/team/team-name.tsx
@@ -69,8 +69,8 @@ const TeamName = ({teamData}: TeamNameProps) => {
 
   return (
     <>
-      <h2>Team Name</h2>
-      <div className="flex flex-col space-y-2">
+      <h2 className="font-semibold text-xl mt-16">Team Name</h2>
+      <div className="flex flex-col space-y-2 mt-6">
         <input
           className="bg-gray-50 dark:bg-gray-800 focus:outline-none focus:shadow-outline border border-gray-300 dark:border-gray-700 rounded-md py-2 px-4 block w-full sm:w-1/2 md:w-1/3 appearance-none leading-normal"
           type="text"
@@ -80,7 +80,7 @@ const TeamName = ({teamData}: TeamNameProps) => {
         />
         <div className="flex flex-row space-x-2">
           <button
-            className={`text-white bg-green-600 border-0 py-0 px-4 focus:outline-none rounded
+            className={`text-white bg-green-600 border-0 py-2 px-4 focus:outline-none rounded-md
                     ${
                       teamNameNeedsSaving
                         ? 'hover:bg-green-700'
@@ -101,10 +101,10 @@ const TeamName = ({teamData}: TeamNameProps) => {
             Save
           </button>
           <button
-            className={`bg-white border-0 py-0 px-4 focus:outline-none rounded
+            className={`border border-gray-300 dark:border-0 dark:bg-gray-700 py-2 px-4 focus:outline-none rounded-md
                     ${
                       teamNameNeedsSaving
-                        ? 'hover:bg-gray-200'
+                        ? 'hover:bg-gray-200 dark:hover:bg-gray-800'
                         : 'cursor-not-allowed opacity-50'
                     }`}
             type="button"

--- a/src/lib/teams.ts
+++ b/src/lib/teams.ts
@@ -1,6 +1,8 @@
 import {getGraphQLClient} from '../utils/configured-graphql-client'
 
-export async function loadTeams(token: string) {
+type TeamResponse = {data: Array<any> | undefined}
+
+export async function loadTeams(token: string): Promise<TeamResponse> {
   const query = /* GraphQL */ `
     query getAccounts {
       accounts {
@@ -32,6 +34,6 @@ export async function loadTeams(token: string) {
   } catch (e) {
     console.error(e)
     console.error(e.response.errors)
-    return
+    return {data: undefined}
   }
 }


### PR DESCRIPTION
* Expand on the team request typing, remove viewer

* Move Copy to Clipboard component to own file

* Use a yellow link against burnt orange background

* Apply prose dark-mode to team account section

* Add dark-mode background styles for member table

* Adjust a couple gray buttons for dark mode

* wip

* h1

* subtitle

* TeamName

* tweaks

* tweaks

* clean up

Co-authored-by: Evgeniy Nagalskiy <evgeniy.nagalskiy@gmail.com>